### PR TITLE
Improve metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 0.1.0
+
+- TelemetryDeck SDK is now available for macOS apps
+- Improvements to documentation and pub.dev listing
+
 ## 0.0.5
 
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.0.5
-
 
 ## 0.0.4
 

--- a/macos/telemetrydecksdk.podspec
+++ b/macos/telemetrydecksdk.podspec
@@ -5,13 +5,13 @@
 Pod::Spec.new do |s|
   s.name             = 'telemetrydecksdk'
   s.version          = '0.0.1'
-  s.summary          = 'A new Flutter plugin project.'
+  s.summary          = 'Flutter SDK for TelemetryDeck, a privacy-conscious analytics service for apps and websites.'
   s.description      = <<-DESC
-A new Flutter plugin project.
+Flutter SDK for TelemetryDeck, a privacy-conscious analytics service for apps and websites.
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://telemetrydeck.com'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'TelemetryDeck' => 'info@telemetrydeck.com' }
 
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: telemetrydecksdk
 description: "Flutter SDK for TelemetryDeck, a privacy-conscious analytics service for apps and websites"
 version: 0.0.5
 homepage: "https://telemetrydeck.com"
+repository: "https://github.com/TelemetryDeck/FlutterSDK"
 
 environment:
   sdk: ">=3.2.3 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,8 @@ description: "Flutter SDK for TelemetryDeck, a privacy-conscious analytics servi
 version: 0.0.5
 homepage: "https://telemetrydeck.com"
 repository: "https://github.com/TelemetryDeck/FlutterSDK"
+issue_tracker: "https://github.com/TelemetryDeck/FlutterSDK/issues"
+documentation: "https://telemetrydeck.com/docs/"
 
 environment:
   sdk: ">=3.2.3 <4.0.0"


### PR DESCRIPTION
Makes the following links available on the package homepage at https://pub.dev/packages/telemetrydecksdk

* repository
* documentation
* issue tracker

This PR should address #2 

changelog has been updated with release notes for version `0.1.0`.