### PR TITLE
Disable automated lifecycle signals for android

### DIFF
--- a/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
+++ b/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
@@ -2,6 +2,8 @@ package com.telemetrydeck.telemetrydecksdk
 
 import android.app.Application
 import android.content.Context
+import com.telemetrydeck.sdk.EnvironmentMetadataProvider
+import com.telemetrydeck.sdk.SessionProvider
 import com.telemetrydeck.sdk.TelemetryManager
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -106,9 +108,11 @@ class TelemetrydecksdkPlugin: FlutterPlugin, MethodCallHandler {
       val testMode = arguments["testMode"] as? Boolean
 
 
-      // initialize the client
+      // Initialize the client
+      // Do not activate the lifecycle provider
       val builder = TelemetryManager.Builder()
         .appID(appID)
+        .providers(listOf(SessionProvider(), EnvironmentMetadataProvider()))
 
       apiBaseURL?.let {
         builder.baseURL(it)


### PR DESCRIPTION
This PR disables the lifecycle telemetry provider for Android. As a result, the following signals are no longer sent:

* onStart
* onStop
* onActivityCreated
* onActivityStarted
* onActivityResumed
* onActivityPaused
* onActivityStopped
* onActivitySaveInstanceState
* onActivityDestroyed


This can help address #5 