### PR TITLE
Correctly set isTestMode for Android targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ migrate_working_dir/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 # Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,33 @@
 ## 0.4.0
+
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.4.0
 - Updated `flutter_lints` dependency
 - Updated package to make it compliant with flutter package rules
 - Made all calls in `Telemetrydecksdk` class static - no need to create an instance anymore
 - `additionalPayload` takes a `Map<String, dynamic>`now instead of a `Map<String, String>` and values will now be stringified automatically
+- [Fixes](https://github.com/TelemetryDeck/KotlinSDK/pull/27) an issue which causes signals from Android to always appear in test mode.
 
 ## 0.3.0
+
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.3.0
 
 ## 0.2.0
+
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.2.0
 
 ## 0.1.0
+
 - TelemetryDeck SDK is now available for macOS apps
 - Improvements to documentation and pub.dev listing
 
 ## 0.0.5
+
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.0.5
 
 ## 0.0.4
+
 - The initial release of TelemetryDeck SDK for Flutter
 
 ## 0.0.3
+
 - The initial release of TelemetryDeck SDK for Flutter


### PR DESCRIPTION
This PR takes the latest version of the Kotlin SDK and fixes #6

Please merge after Kotlin SDK 2.0.2 has been released and available from JitPack.
