### PR TITLE
Invoking stop() should be done from the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1
+
+- https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.5.1
+- Fix a possible crash when calling `stop()`.
+
 ## 0.5.0
 
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.5.0

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Prevent signals from being sent using the stop method:
 Telemetrydecksdk.stop()
 ```
 
-In order to restart sending events, you will need to call the `start` method again.
+This also prevents previously cached signals from being sent. In order to restart sending events, you will need to call the `start` method again.
 
 ## Navigation signals
 

--- a/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
+++ b/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import com.telemetrydeck.sdk.EnvironmentMetadataProvider
 import com.telemetrydeck.sdk.SessionProvider
 import com.telemetrydeck.sdk.TelemetryManager
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -34,34 +33,41 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
-      when (call.method) {
-          "start" -> {
-              nativeInitialize(call, result)
-          }
-          "stop" -> {
-              nativeStop(result)
-          }
-          "send" -> {
-              // this maps to the queue method which aligns with the behaviour of the iOS SDK
-              nativeQueue(call, result)
-          }
-          "generateNewSession" -> {
-              TelemetryManager.newSession()
-              result.success(null)
-          }
-          "updateDefaultUser" -> {
-              nativeUpdateDefaultUser(call, result)
-          }
-          "navigate" -> {
-              nativeNavigate(call, result)
-          }
-          "navigateToDestination" -> {
-              nativeNavigateDestination(call, result)
-          }
-          else -> {
-              result.notImplemented()
-          }
-      }
+        when (call.method) {
+            "start" -> {
+                nativeInitialize(call, result)
+            }
+
+            "stop" -> {
+                nativeStop(result)
+            }
+
+            "send" -> {
+                // this maps to the queue method which aligns with the behaviour of the iOS SDK
+                nativeQueue(call, result)
+            }
+
+            "generateNewSession" -> {
+                TelemetryManager.newSession()
+                result.success(null)
+            }
+
+            "updateDefaultUser" -> {
+                nativeUpdateDefaultUser(call, result)
+            }
+
+            "navigate" -> {
+                nativeNavigate(call, result)
+            }
+
+            "navigateToDestination" -> {
+                nativeNavigateDestination(call, result)
+            }
+
+            else -> {
+                result.notImplemented()
+            }
+        }
     }
 
     /**
@@ -110,12 +116,8 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun nativeStop(result: Result) {
-        coroutineScope.launch {
-            TelemetryManager.stop()
-            withContext(Dispatchers.Main) {
-                result.success(null)
-            }
-        }
+        TelemetryManager.stop()
+        result.success(null)
     }
 
     private fun nativeUpdateDefaultUser(

--- a/lib/src/telemetry_manager_configuration.dart
+++ b/lib/src/telemetry_manager_configuration.dart
@@ -16,8 +16,8 @@ class TelemetryManagerConfiguration {
   /// Default is `false`.
   final bool? debug;
 
-  /// If `true` any signals sent will be marked as *Testing* signals.
-  /// Default is `false`.
+  /// When `true`, any signals sent will be marked as *Testing* signals.
+  /// If `testMode` is not set explicitly, the corresponding native SDK will automatically determine the value based on whether this is a debug or release build of the app.
   final bool? testMode;
 
   const TelemetryManagerConfiguration({


### PR DESCRIPTION
This PR addresses #16 by adapting the way we call `stop()` in the KotlinSDK. Since `start()` and `stop()` manage subscriptions for lifecycle events, they always need to be invoked on the main thread. 

The README has been updated to clarify the effect of `stop()`.

We can consider improving the KotlinSDK in the future to ensure both method calls are executed on the main loop, however this will require some consideration for the way we implement the `TelemetryProvider` interface which is public and allows custom implementations to be provided to the SDK.