### PR TITLE
Update coordinates for KotlinSDK to Maven Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0
+
+- https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.6.0
+- Update coordinates for Kotlin SDK to Maven Central
+
 ## 0.5.1
 
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.5.1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ The Flutter SDK depends on the latest major version of the native SDKs. This is 
 On Android, the dependency is configured in `android/build.gradle`:
 
 ```
-implementation 'com.github.TelemetryDeck:KotlinSDK:2.+'
+implementation 'com.telemetrydeck:kotlin-sdk:2.2.0'
 ```
 
 On iOS, the dependency is configured in `ios/telemetrydecksdk.podspec` using the podspect Dependency format `s.dependency 'TelemetryClient', '~> 2.0'`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 
     dependencies {
@@ -19,7 +18,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 }
 
@@ -52,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.github.TelemetryDeck:KotlinSDK:2.+'
+        implementation 'com.telemetrydeck:kotlin-sdk:2.2.0'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -14,7 +14,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -237,7 +237,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.5.1"
   term_glyph:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR adapts the depency for the KotlinSDK to use Maven Central coordinates instead of JitPack