### PR TITLE
Grand Rename for all native SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0
+
+- https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.7.0
+- This version introduces the Grand Rename for all native SDKs. You can read more about the motivation behind these changes [here](https://telemetrydeck.com/docs/articles/grand-rename/).
+- Upgrade to the latest Kotlin SDK version introducing a new `TelemetryDeck` class and [more](https://github.com/TelemetryDeck/KotlinSDK/releases/tag/3.0.3).
+- Upgrade to the latest Swift SDK version with [various improvements](https://github.com/TelemetryDeck/SwiftSDK/compare/2.2.4...2.6.1).
+
 ## 0.6.0
 
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/0.6.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TelemetryDeck SDK for Flutter
 
-This package allows your app to send signals to [TelemetryDeck](https://telemetrydeck.com/) using the native TelemetryDeck libraries for [Kotlin](https://github.com/TelemetryDeck/KotlinSDK) and [iOS](https://github.com/TelemetryDeck/SwiftClient).
+This package allows your app to send signals to [TelemetryDeck](https://telemetrydeck.com/) using the native TelemetryDeck libraries for [Kotlin](https://github.com/TelemetryDeck/KotlinSDK) and [iOS](https://github.com/TelemetryDeck/SwiftSDK).
 
 ## Getting started
 
@@ -60,26 +60,17 @@ Telemetrydecksdk.send(
 );
 ```
 
-The Flutter SDK uses the native SDKs for Android and iOS which offer a number of built-in attributes which are submitted with every signal. You can overwrite these attributes by providing a custom value with the same key. For more information on how each value is calcualted, check the corresponding platform library:
+## Environment Parameters
 
-- `majorMinorSystemVersion`
-- `telemetryClientVersion`
-- `isTestFlight` (iOS only)
-- `isDebug`
-- `architecture`
-- `modelName`
-- `isAppStore`
-- `appVersion`
-- `operatingSystem`
-- `systemVersion`
-- `majorSystemVersion`
-- `targetEnvironment`
-- `isSimulator` (iOS only)
-- `platform` (iOS only)
-- `buildNumber` (iOS only)
-- `locale`
-- `dartVersion`
-- `brand` (Android only)
+The Flutter SDK uses the native SDKs for Android and iOS which offer a number of built-in attributes which are submitted with every signal.
+
+You can overwrite these attributes by providing a custom value with the same key. For more information on how each value is calcualted, check the corresponding platform library.
+
+The Flutter SDK adds the following additional attributes:
+
+| Parameter name                  | Description                                 |
+| ------------------------------- | ------------------------------------------- |
+| `TelemetryDeck.SDK.dartVersion` | The Dart language version used during build |
 
 ## Stop sending signals
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -50,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.telemetrydeck:kotlin-sdk:2.2.0'
+        implementation 'com.telemetrydeck:kotlin-sdk:3.0.3'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
     }

--- a/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
+++ b/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
@@ -2,9 +2,7 @@ package com.telemetrydeck.telemetrydecksdk
 
 import android.app.Application
 import android.content.Context
-import com.telemetrydeck.sdk.EnvironmentMetadataProvider
-import com.telemetrydeck.sdk.SessionProvider
-import com.telemetrydeck.sdk.TelemetryManager
+import com.telemetrydeck.sdk.TelemetryDeck
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -48,7 +46,7 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
             }
 
             "generateNewSession" -> {
-                TelemetryManager.newSession()
+                TelemetryDeck.newSession()
                 result.success(null)
             }
 
@@ -86,7 +84,7 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
         }
 
         coroutineScope.launch {
-            TelemetryManager.navigate(sourcePath, destinationPath, clientUser)
+            TelemetryDeck.navigate(sourcePath, destinationPath, clientUser)
             withContext(Dispatchers.Main) {
                 result.success(null)
             }
@@ -108,7 +106,7 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
         }
 
         coroutineScope.launch {
-            TelemetryManager.navigate(destinationPath, clientUser)
+            TelemetryDeck.navigate(destinationPath, clientUser)
             withContext(Dispatchers.Main) {
                 result.success(null)
             }
@@ -116,7 +114,7 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun nativeStop(result: Result) {
-        TelemetryManager.stop()
+        TelemetryDeck.stop()
         result.success(null)
     }
 
@@ -127,7 +125,7 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
         val user = call.arguments<String>()
 
         coroutineScope.launch {
-            TelemetryManager.newDefaultUser(user)
+            TelemetryDeck.newDefaultUser(user)
             withContext(Dispatchers.Main) {
                 result.success(null)
             }
@@ -144,7 +142,7 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
             val additionalPayload = call.argument<Map<String, String>>("additionalPayload")
 
             coroutineScope.launch {
-                TelemetryManager.queue(signalType, clientUser, additionalPayload.orEmpty())
+                TelemetryDeck.signal(signalType, clientUser, additionalPayload.orEmpty())
 
                 withContext(Dispatchers.Main) {
                     result.success(null)
@@ -175,9 +173,8 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
 
             // Initialize the client
             // Do not activate the lifecycle provider
-            val builder = TelemetryManager.Builder()
+            val builder = TelemetryDeck.Builder()
                 .appID(appID)
-                .providers(listOf(SessionProvider(), EnvironmentMetadataProvider()))
 
             apiBaseURL?.let {
                 builder.baseURL(it)
@@ -193,7 +190,7 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
             }
 
             val application = applicationContext as Application
-            TelemetryManager.start(application, builder)
+            TelemetryDeck.start(application, builder)
             result.success(null)
         } else {
             result.error("INVALID_ARGUMENT", "Arguments are not a map", null)

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Dec 16 15:22:49 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "8.6.1" apply false
 }
 
 include ":app"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - TelemetryDeck (2.2.4)
+  - TelemetryDeck (2.6.1)
   - telemetrydecksdk (1.0.0):
     - Flutter
-    - TelemetryDeck (~> 2.2.4)
+    - TelemetryDeck (~> 2.6.1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -26,10 +26,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
-  TelemetryDeck: 0fc448990840a22174112c89e7e9ee484e11ca50
-  telemetrydecksdk: 1c83be11619131dffd4ff1c403f809f4469c8806
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  TelemetryDeck: d33fc31e687aff7a2e18d770a011453144501193
+  telemetrydecksdk: 0ee3f9f9d66b39e26434fee4d94efc95bf94498e
 
 PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -102,18 +102,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -142,18 +142,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -166,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -190,7 +190,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   sync_http:
     dependency: transitive
     description:
@@ -237,7 +237,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.1"
+    version: "0.6.0"
   term_glyph:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -266,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.3.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/TelemetrydecksdkPlugin.swift
+++ b/ios/Classes/TelemetrydecksdkPlugin.swift
@@ -44,8 +44,10 @@ public class TelemetrydecksdkPlugin: NSObject, FlutterPlugin {
             return
         }
         let clientUser = arguments["clientUser"] as? String
-        TelemetryDeck.navigationPathChanged(from: sourcePath, to: destinationPath, customUserID: clientUser)
-        result(nil)
+        DispatchQueue.main.async {
+            TelemetryDeck.navigationPathChanged(from: sourcePath, to: destinationPath, customUserID: clientUser)
+            result(nil)
+        }
     }
     
     /**
@@ -60,8 +62,10 @@ public class TelemetrydecksdkPlugin: NSObject, FlutterPlugin {
             return
         }
         let clientUser = arguments["clientUser"] as? String
-        TelemetryDeck.navigationPathChanged(to: destinationPath, customUserID: clientUser)
-        result(nil)
+        DispatchQueue.main.async {
+            TelemetryDeck.navigationPathChanged(to: destinationPath, customUserID: clientUser)
+            result(nil)
+        }
     }
     
     private func nativeStop(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -120,7 +124,7 @@ public class TelemetrydecksdkPlugin: NSObject, FlutterPlugin {
         if arguments.keys.contains("debug") {
             if arguments["debug"] as? Bool == true {
                 // by default, the library logs with level .info
-                configuration.logHandler = LogHandler.stdout(.debug)
+                configuration.logHandler = LogHandler.standard(.debug)
             }
         }
         

--- a/ios/telemetrydecksdk.podspec
+++ b/ios/telemetrydecksdk.podspec
@@ -15,7 +15,7 @@ Flutter SDK for TelemetryDeck, a privacy-conscious analytics service for apps an
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'TelemetryDeck', '~> 2.2.4'
+  s.dependency 'TelemetryDeck', '~> 2.6.1'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/src/telemetry_provider.dart
+++ b/lib/src/telemetry_provider.dart
@@ -12,8 +12,11 @@ class TelemetryProvider {
   /// This method will overwrite the default `telemetryClientVersion`.
   Future<Map<String, dynamic>> enrich(Map<String, dynamic>? payload) async {
     Map<String, dynamic> result = payload ?? {};
-    result['telemetryClientVersion'] = "Flutter $telemetryClientVersion";
-    result['dartVersion'] = versionReader.readVersion();
+    result['TelemetryDeck.SDK.name'] = "Flutter SDK";
+    result['TelemetryDeck.SDK.version'] = telemetryClientVersion;
+    result['TelemetryDeck.SDK.nameAndVersion'] =
+        "Flutter SDK $telemetryClientVersion";
+    result['TelemetryDeck.SDK.dartVersion'] = versionReader.readVersion();
 
     return result;
   }


### PR DESCRIPTION
This PR updates the native SDKs to their latest version and introduces various improvements following the [Grand Rename](https://telemetrydeck.com/docs/articles/grand-rename/).

As this is a breaking change, the new version will be `1.0.0`