### PR TITLE
Allow setting default signal and parameter prefix, default parameters for all outgoing signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 2.1.0
 
 - https://github.com/TelemetryDeck/FlutterSDK/releases/tag/2.1.0
-- The SwiftSDK for macOS has been updated to version [2.7.0](https://github.com/TelemetryDeck/SwiftSDK/releases/tag/2.7.0)
-- The SwiftSDK for iOS has been updated to version [2.7.0](https://github.com/TelemetryDeck/SwiftSDK/releases/tag/2.7.0)
+
+- It's now possible to set defaultSignalPrefix, defaultParameterPrefix as well as a map of defaultParameters in the `TelemetryManagerConfiguration` class. This allows you to set default values for all signals and parameters sent by the SDK.
+
+- The SwiftSDK for macOS has been updated to version [2.7.2](https://github.com/TelemetryDeck/SwiftSDK/releases/tag/2.7.2)
+- The SwiftSDK for iOS has been updated to version [2.7.2](https://github.com/TelemetryDeck/SwiftSDK/releases/tag/2.7.2)
 - The KotlinSDK for Android has been updated to [4.1.0](https://github.com/TelemetryDeck/KotlinSDK/releases/tag/4.1.0)
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -82,6 +82,30 @@ Telemetrydecksdk.stop()
 
 This also prevents previously cached signals from being sent. In order to restart sending events, you will need to call the `start` method again.
 
+## Default Parameters
+
+If there are parameters you would like to include with every outgoing signal, you can configure `Telemetrydecksdk` to do so instead of passing them with every call:
+
+```dart
+const TelemetryManagerConfiguration(
+  // ...
+        defaultParameters: {"ParameterName": "ParameterValue"}
+        ),
+```
+
+## Default Prefix
+
+If you find yourself prepending the same prefix for to your custom signals or parameters,
+you can optionally configure `Telemetrydecksdk` to do this for you:
+
+```dart
+const TelemetryManagerConfiguration(
+  // ...
+        defaultParameterPrefix: "DemoApp.Parameter.",
+        defaultSignalPrefix: "DemoApp.Signal.",
+        ),
+```
+
 ## Navigation signals
 
 A navigation signal is a regular TelemetryDeck signal of type `TelemetryDeck.Navigation.pathChanged`. Automatic navigation tracking is available using the `navigate` and `navigateToDestination` methods:

--- a/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
+++ b/android/src/main/kotlin/com/telemetrydeck/telemetrydecksdk/TelemetrydecksdkPlugin.kt
@@ -3,6 +3,8 @@ package com.telemetrydeck.telemetrydecksdk
 import android.app.Application
 import android.content.Context
 import com.telemetrydeck.sdk.TelemetryDeck
+import com.telemetrydeck.sdk.providers.DefaultParameterProvider
+import com.telemetrydeck.sdk.providers.DefaultPrefixProvider
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -170,6 +172,9 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
             val debug = arguments["debug"] as? Boolean
             val testMode = arguments["testMode"] as? Boolean
             val salt = arguments["salt"] as? String?
+            val defaultSignalPrefix = arguments["defaultSignalPrefix"] as? String?
+            val defaultParameterPrefix = arguments["defaultParameterPrefix"] as? String?
+            val defaultParameters = arguments["defaultParameters"] as? Map<String, String>?
 
 
             // Initialize the client
@@ -191,6 +196,14 @@ class TelemetrydecksdkPlugin : FlutterPlugin, MethodCallHandler {
             }
             salt?.let {
                 builder.salt(it)
+            }
+
+            if (defaultSignalPrefix != null || defaultParameterPrefix != null) {
+                builder.addProvider(DefaultPrefixProvider(defaultSignalPrefix, defaultParameterPrefix))
+            }
+
+            if (defaultParameters != null) {
+                builder.addProvider(DefaultParameterProvider(defaultParameters))
             }
 
             val application = applicationContext as Application

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - TelemetryDeck (2.7.0)
+  - TelemetryDeck (2.7.2)
   - telemetrydecksdk (1.0.0):
     - Flutter
-    - TelemetryDeck (~> 2.7.0)
+    - TelemetryDeck (~> 2.7.2)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  TelemetryDeck: c3195d6cbb246cb822c44d63d8b099f341a1bc57
-  telemetrydecksdk: ab84a7d4a6fe053b8e65d58edc986efba606958d
+  TelemetryDeck: 481e582ca2040a79d81f03e8c93fc9360b095814
+  telemetrydecksdk: 5b729e8dedc0e07a1c17906c9cccd31561505ca9
 
 PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,9 @@ void main() {
   Telemetrydecksdk.start(
     const TelemetryManagerConfiguration(
         appID: "22385F1C-3699-4F04-9D63-24CC0B2E62D8",
+        defaultParameterPrefix: "DemoApp.Parameter.",
+        defaultSignalPrefix: "DemoApp.Signal.",
+        defaultParameters: {"ParameterName": "ParameterValue"},
         debug: true,
         testMode: true),
   );

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - TelemetryDeck (2.7.0)
+  - TelemetryDeck (2.7.2)
   - telemetrydecksdk (0.0.1):
     - FlutterMacOS
     - TelemetryDeck (~> 2.7.0)
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  TelemetryDeck: c3195d6cbb246cb822c44d63d8b099f341a1bc57
+  TelemetryDeck: 481e582ca2040a79d81f03e8c93fc9360b095814
   telemetrydecksdk: 74918d69fff5a76eb85ab192036f81c5a51ad1a6
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367

--- a/ios/Classes/TelemetrydecksdkPlugin.swift
+++ b/ios/Classes/TelemetrydecksdkPlugin.swift
@@ -134,6 +134,19 @@ public class TelemetrydecksdkPlugin: NSObject, FlutterPlugin {
             configuration.testMode = arguments["testMode"] as? Bool == true
         }
         
+        if arguments.keys.contains("defaultSignalPrefix") {
+            configuration.defaultSignalPrefix = arguments["defaultSignalPrefix"] as? String
+        }
+        
+        if arguments.keys.contains("defaultParameterPrefix") {
+            configuration.defaultParameterPrefix = arguments["defaultParameterPrefix"] as? String
+        }
+        
+        if arguments.keys.contains("defaultParameters") {
+            let finalValues = arguments["defaultParameters"] as? [String : String] ?? [:]
+            configuration.defaultParameters = { finalValues }
+        }
+        
         TelemetryDeck.initialize(config: configuration)
         
         result(nil)

--- a/ios/telemetrydecksdk.podspec
+++ b/ios/telemetrydecksdk.podspec
@@ -15,7 +15,7 @@ Flutter SDK for TelemetryDeck, a privacy-conscious analytics service for apps an
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'TelemetryDeck', '~> 2.7.0'
+  s.dependency 'TelemetryDeck', '~> 2.7.2'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/src/telemetry_manager_configuration.dart
+++ b/lib/src/telemetry_manager_configuration.dart
@@ -22,13 +22,20 @@ class TelemetryManagerConfiguration {
 
   final String? salt;
 
+  final String? defaultSignalPrefix;
+  final String? defaultParameterPrefix;
+  final Map<String, String>? defaultParameters;
+
   const TelemetryManagerConfiguration(
       {required this.appID,
       this.apiBaseURL,
       this.defaultUser,
       this.debug,
       this.testMode,
-      this.salt});
+      this.salt,
+      this.defaultSignalPrefix,
+      this.defaultParameterPrefix,
+      this.defaultParameters});
 
   /// to map
   Map<String, dynamic> toMap() {
@@ -38,7 +45,10 @@ class TelemetryManagerConfiguration {
       'defaultUser': defaultUser,
       'debug': debug,
       'testMode': testMode,
-      'salt': salt
+      'salt': salt,
+      'defaultSignalPrefix': defaultSignalPrefix,
+      'defaultParameterPrefix': defaultParameterPrefix,
+      'defaultParameters': defaultParameters
     };
   }
 }

--- a/lib/src/telemetry_manager_configuration.dart
+++ b/lib/src/telemetry_manager_configuration.dart
@@ -51,4 +51,20 @@ class TelemetryManagerConfiguration {
       'defaultParameters': defaultParameters
     };
   }
+
+  TelemetryManagerConfiguration copyWith({
+    Map<String, String>? defaultParameters,
+  }) {
+    return TelemetryManagerConfiguration(
+      appID: appID,
+      apiBaseURL: apiBaseURL,
+      defaultUser: defaultUser,
+      debug: debug,
+      testMode: testMode,
+      salt: salt,
+      defaultSignalPrefix: defaultSignalPrefix,
+      defaultParameterPrefix: defaultParameterPrefix,
+      defaultParameters: defaultParameters ?? this.defaultParameters,
+    );
+  }
 }

--- a/lib/src/telemetry_provider.dart
+++ b/lib/src/telemetry_provider.dart
@@ -11,7 +11,7 @@ class TelemetryProvider {
   /// Adds Flutter specific payload attributes to outgoing signals before passing them to the native platform API.
   /// This method will overwrite the default `telemetryClientVersion`.
   Future<Map<String, dynamic>> enrich(Map<String, dynamic>? payload) async {
-    Map<String, dynamic> result = payload ?? {};
+    Map<String, dynamic> result = Map<String, dynamic>.from(payload ?? {});
     result['TelemetryDeck.SDK.name'] = "Flutter SDK";
     result['TelemetryDeck.SDK.version'] = telemetryClientVersion;
     result['TelemetryDeck.SDK.nameAndVersion'] =

--- a/lib/src/telemetrydecksdk.dart
+++ b/lib/src/telemetrydecksdk.dart
@@ -11,7 +11,16 @@ abstract class Telemetrydecksdk {
   static const _telemetryProvider = TelemetryProvider();
 
   static Future<void> start(TelemetryManagerConfiguration configuration) async {
-    await TelemetrydecksdkPlatform.instance.start(configuration);
+    final enrichedDefaultParameters = await _telemetryProvider.enrich(
+      configuration.defaultParameters,
+    );
+    final stringifiedeParams = enrichedDefaultParameters.map(
+      (key, value) => MapEntry(key, value.toString()),
+    );
+    final enrichedConfiguration = configuration.copyWith(
+      defaultParameters: stringifiedeParams,
+    );
+    await TelemetrydecksdkPlatform.instance.start(enrichedConfiguration);
   }
 
   static Future<void> stop() async {
@@ -23,7 +32,7 @@ abstract class Telemetrydecksdk {
     String? clientUser,
     Map<String, dynamic>? additionalPayload,
   }) async {
-    final payload = await _telemetryProvider.enrich(additionalPayload);
+    final payload = additionalPayload ?? {};
 
     final stringifiedPayload = payload.map(
       (key, value) => MapEntry(key, value.toString()),

--- a/macos/Classes/TelemetrydecksdkPlugin.swift
+++ b/macos/Classes/TelemetrydecksdkPlugin.swift
@@ -135,6 +135,19 @@ private func nativeInitialize(_ call: FlutterMethodCall, result: @escaping Flutt
         configuration.testMode = arguments["testMode"] as? Bool == true
     }
     
+    if arguments.keys.contains("defaultSignalPrefix") {
+        configuration.defaultSignalPrefix = arguments["defaultSignalPrefix"] as? String
+    }
+    
+    if arguments.keys.contains("defaultParameterPrefix") {
+        configuration.defaultParameterPrefix = arguments["defaultParameterPrefix"] as? String
+    }
+    
+    if arguments.keys.contains("defaultParameters") {
+        let finalValues = arguments["defaultParameters"] as? [String : String] ?? [:]
+        configuration.defaultParameters = { finalValues }
+    }
+    
     TelemetryDeck.initialize(config: configuration)
     
     result(nil)

--- a/test/telemetry_provider_test.dart
+++ b/test/telemetry_provider_test.dart
@@ -10,8 +10,12 @@ void main() {
     // assert the keys 'key1' is present in the result
     expect(
       result,
-      containsPair('telemetryClientVersion', "Flutter $telemetryClientVersion"),
+      containsPair('TelemetryDeck.SDK.version', telemetryClientVersion),
     );
-    expect(result, containsPair('dartVersion', isNotNull));
+    expect(
+      result,
+      containsPair('TelemetryDeck.SDK.name', 'Flutter SDK'),
+    );
+    expect(result, containsPair('TelemetryDeck.SDK.dartVersion', isNotNull));
   });
 }


### PR DESCRIPTION
This PR makes it possible to set the following additional properties:

`defaultSignalPrefix` - Specify this if you want us to prefix all your signals with a specific text.

`defaultParameterPrefix` - Specify this if you want us to prefix all your signal parameters with a specific text.

`defaultParameters` - A map of parameters to be appended to all outgoing signals.

This PR fixes #25 and fixes #22


Note: There is a known issue for iOS/macOS targets where some internal parameters will not be sent correctly when a default prefix is set (https://github.com/TelemetryDeck/SwiftSDK/issues/227).