### PR TITLE
Update native sdks to the latest version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,4 +24,6 @@ implementation 'com.telemetrydeck:kotlin-sdk:2.2.0'
 
 On iOS, the dependency is configured in `ios/telemetrydecksdk.podspec` using the podspect Dependency format `s.dependency 'TelemetryClient', '~> 2.0'`.
 
+On macOS, the dependency is configured in `macos/telemetrydecksdk.podspec` using the podspect Dependency format `s.dependency 'TelemetryClient', '~> 2.0'`.
+
 Note: CocoaPods requires running `pod update` to fetch the latest version of the native SDK for both iOS and macOS. You can do so in the ios and macOS folders of the example project.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.telemetrydeck:kotlin-sdk:6.0.1'
+        implementation 'com.telemetrydeck:kotlin-sdk:6.1.0'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - TelemetryDeck (2.9.1)
+  - TelemetryDeck (2.9.3)
   - telemetrydecksdk (1.0.0):
     - Flutter
-    - TelemetryDeck (~> 2.9.1)
+    - TelemetryDeck (~> 2.9.3)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  TelemetryDeck: 2d31ff48e93fd37f2a9f257dba5d633ea11ed9ff
-  telemetrydecksdk: c165a0d35ee4aaab20a7dcbd6156ef8ce68a8571
+  TelemetryDeck: 5331ca64c53ab1ab6162c558c8b46b412c744483
+  telemetrydecksdk: 99b635696b35527877d918a9844a798a24e1828b
 
 PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - TelemetryDeck (2.9.1)
+  - TelemetryDeck (2.9.3)
   - telemetrydecksdk (0.0.1):
     - FlutterMacOS
-    - TelemetryDeck (~> 2.9.1)
+    - TelemetryDeck (~> 2.9.3)
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  TelemetryDeck: 2d31ff48e93fd37f2a9f257dba5d633ea11ed9ff
-  telemetrydecksdk: 1d9828cd24aa8be1448b840a8a025d9dbbfe058f
+  TelemetryDeck: 5331ca64c53ab1ab6162c558c8b46b412c744483
+  telemetrydecksdk: 93d7906aee5406574bc5a5dc4e6027d9bd429c43
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367
 

--- a/ios/telemetrydecksdk.podspec
+++ b/ios/telemetrydecksdk.podspec
@@ -15,7 +15,7 @@ Flutter SDK for TelemetryDeck, a privacy-conscious analytics service for apps an
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'TelemetryDeck', '~> 2.9.1'
+  s.dependency 'TelemetryDeck', '~> 2.9.3'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/macos/telemetrydecksdk.podspec
+++ b/macos/telemetrydecksdk.podspec
@@ -16,7 +16,7 @@ Flutter SDK for TelemetryDeck, a privacy-conscious analytics service for apps an
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.dependency 'TelemetryDeck', '~> 2.9.1'
+  s.dependency 'TelemetryDeck', '~> 2.9.3'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
This is a maintenance PR, updating the native SDKs to their latest versions:

- SwiftSDK https://github.com/TelemetryDeck/SwiftSDK/releases/tag/2.9.3
- KotlinSDK https://github.com/TelemetryDeck/KotlinSDK/releases/tag/6.1.0